### PR TITLE
fix small code highlighting error

### DIFF
--- a/iOS/swift.md
+++ b/iOS/swift.md
@@ -8,11 +8,11 @@ Good programmers write good code: code that is consistent and readable. A consis
 
 Many style choices are subjective or arbitrary. Good programmers disagree about the best choices in many cases. Regardless of your personal likes and dislikes, regardless of your stance on commas or colons, each member of a team is expected to select and follow the house style to the best of their abilities and to use that style when evaluating and other people's code within the same organization.
 
-Our style is based on conventional industry coding. 
+Our style is based on conventional industry coding.
 
 ## Correctness
 
-Correctness is not a style. It's a prerequisite. And that's why it is the first topic covered here in this style guide. Your code must compile without warnings. Code that produces warnings by definition does not meet our code style standards. When a warning is unavoidable, you must document the reason behind that warning. Where appropriate, instruct the the compiler to ignore it, to better bring your code in line with this first rule. 
+Correctness is not a style. It's a prerequisite. And that's why it is the first topic covered here in this style guide. Your code must compile without warnings. Code that produces warnings by definition does not meet our code style standards. When a warning is unavoidable, you must document the reason behind that warning. Where appropriate, instruct the the compiler to ignore it, to better bring your code in line with this first rule.
 
 ## Lambda Core Style
 
@@ -25,7 +25,7 @@ Here are the basic elements of style we expect you to adopt here at Lambda:
 * Lambda always leaves spaces between braces and co-linear text, so `{ return }`, not `{return}`.
 * Lambda omits parens around `if` and `switch` conditions, so `if condition` not `if (condition)`.
 * Lambda uses UpperCamelCase names for types and protocols. User lowerCamelCaseNames for type members including properties and methods. Avoid underscores except as prefixes specifically meant to indicate private variable use.
-* Lambda uses meaningful names. "i" is not a meaningful name, nor is "j" or "k", or "prop1" or "vc" or "uitvc". Prefer to use appropriate words that relate to roles, such as `for (key, value) in dict` and `for index in array.indices` and `for value in sequence`. 
+* Lambda uses meaningful names. "i" is not a meaningful name, nor is "j" or "k", or "prop1" or "vc" or "uitvc". Prefer to use appropriate words that relate to roles, such as `for (key, value) in dict` and `for index in array.indices` and `for value in sequence`.
 * Lambda prefers multi-line clauses:
 ```
 if index == count { // prefer
@@ -44,7 +44,7 @@ guard let url = URL(string: "...") else {
 * Lambda uses the default `weak` form for `@IBOutlet`. It is acceptable to remove the `weak` keyword and use strong outlets so long as you do so consistently across your project.
 * Lambda uses `Void` return types, not `()`. Prefer `-> Void` for closure arguments over `-> ()`.
 * Lambda omits semicolons, and especially trailing semicolons in its code. Use "statement" not "statement;"
-* Prefer `.toggle()` to `someBool = !someBool", prefer `string.isEmpty` to `string.count == 0` or `string == ""`.
+* Prefer `.toggle()` to `someBool = !someBool`, prefer `string.isEmpty` to `string.count == 0` or `string == ""`.
 
 ## Organization
 
@@ -67,7 +67,7 @@ Descriptive and consistent naming makes code easier to read and understand. The 
 - Uses of Boolean methods and properties should read as assertions about the receiver. For example, `x.isEmpty`, and `line1.intersects(line2)`
 - **Name protocols with nouns and adjectives**. Protocols that describe what something _is_ should read as nouns (e.g. `Collection`). Protocols that describe a _capability_ should have the suffixes `able`, `ible`, or `ing` (e.g. `Equatable`, `ProgressReporting`).
 - **Avoid obscure terms**. Don’t say “epidermis” if “skin” will serve your purpose.
-- **Avoid abbreviations**. Abbreviations, especially non-standard ones, make your code significantly less clear and readable. For example, `button`, not `btn`. 
+- **Avoid abbreviations**. Abbreviations, especially non-standard ones, make your code significantly less clear and readable. For example, `button`, not `btn`.
 - **Prefer methods and properties over free functions.**. Free functions, that is functions declared at the global scope, should only be used in special cases. Instead, nest functions into the most natural parent type as static members.
 - **Internal parameter names are important.** Even though they don't appear where a function is called, internal parameter names make function signatures, function implementations, and documentation easier to read.
 - **Default argument values simplify common uses.** Any parameter with a single commonly-used value is a candidate for a default. Prefer to locate parameters with defaults toward the end of the parameter list.


### PR DESCRIPTION
This PR fixes a small code highlighting error in which a quotation mark was incorrectly placed where a back tick should have been.